### PR TITLE
feature: Accept optional git revision range

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,18 @@ Clone or download the script to your machine and simply call it from the command
 
 Call the script within a Git repository, and it will print a summary of changes to STDOUT in reverse-chronological order.
 
+### Output
 It will default to printing in Markdown ([example](CHANGELOG.md)), but will print plain text as well ([example](CHANGELOG)) if you pass an argument:
 ```sh
 ./changelog.awk               # outputs Markdown
 ./changelog.awk -v TYPE=plain # outputs plain text
+```
+
+### Revision range
+The whole git log will be processed by default. But revision range can be provided in [git accepted format](https://www.git-scm.com/docs/gitrevisions). Use quotes if more than one arguments are specified.
+```sh
+./changelog.awk -v REVISION_RANGE=1.4.0
+./changelog.awk -v REVISION_RANGE="^1.4.0 1.8.0"
 ```
 
 #### For NPM users

--- a/changelog.awk
+++ b/changelog.awk
@@ -28,7 +28,7 @@ BEGIN {
 	# %h: short hash
 
 	i = 1
-	while ("git log --date=short --pretty='%D|%s|%H|%h|%cd|%an'" | getline) {
+	while ("git log --date=short --pretty='%D|%s|%H|%h|%cd|%an' " REVISION_RANGE | getline) {
 		LINES[i] = $0
 		i++
 	}


### PR DESCRIPTION
Add an optional revision range argument (REVISION_RANGE) which then passed to _git log_ as is.
Allows to generate a changelog for subset of commits/releases.